### PR TITLE
fixed gcc 15.2.1 compilation error with uninitialized field

### DIFF
--- a/src/spb-proto-compiler/ast/proto-common.h
+++ b/src/spb-proto-compiler/ast/proto-common.h
@@ -32,11 +32,11 @@ struct proto_reserved
 struct cpp_ident
 {
     //- points to .proto file
-    std::string_view proto_name;
+    std::string_view proto_name{};
 
     //- cpp compatible identifier in case that `proto_name` can't be used in cpp directly
     //- ('private' -> 'private_')
-    std::string cpp_name;
+    std::string cpp_name{};
 
     auto get_name( ) const -> std::string_view
     {


### PR DESCRIPTION
fixed gcc 15.2.1 compilation error
```
/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/include/c++/bits/basic_string.h:239:28: error: ‘new_field.proto_field::<unnamed>.proto_base::name.cpp_ident::cpp_name.std::__cxx11::basic_string<char>::_M_dataplus.std::__cxx11::basic_string<char>::_Alloc_hider::_M_p’ may be used uninitialized [-Werror=maybe-uninitialized]
  239 |       { return _M_dataplus._M_p; }
      |                            ^~~~
/home/tonda/tmp/simple-protobuf/src/spb-proto-compiler/parser/parser.cpp: In function ‘void {anonymous}::parse_message_body(spb::char_stream&, proto_messages&, proto_comment&&)’:
/home/tonda/tmp/simple-protobuf/src/spb-proto-compiler/parser/parser.cpp:756:10: note: ‘new_field’ declared here
  756 |     auto new_field = proto_field{
      |          ^~~~~~~~~
In member function ‘constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_dispose() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::~basic_string() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/include/c++/bits/basic_string.h:896:19,
    inlined from ‘void {anonymous}::parse_field(spb::char_stream&, proto_fields&, proto_comment&&)’ at /home/tonda/tmp/simple-protobuf/src/spb-proto-compiler/parser/parser.cpp:759:5,
    inlined from ‘void {anonymous}::parse_message_body(spb::char_stream&, proto_messages&, proto_comment&&)’ at /home/tonda/tmp/simple-protobuf/src/spb-proto-compiler/parser/parser.cpp:909:24:
/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/include/c++/bits/basic_string.h:299:21: error: ‘new_field.proto_field::<unnamed>.proto_base::name.cpp_ident::cpp_name.std::__cxx11::basic_string<char>::<anonymous>.std::__cxx11::basic_string<char>::<unnamed union>::_M_allocated_capacity’ may be used uninitialized [-Werror=maybe-uninitialized]
  299 |           _M_destroy(_M_allocated_capacity);
      |           ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/home/tonda/tmp/simple-protobuf/src/spb-proto-compiler/parser/parser.cpp: In function ‘void {anonymous}::parse_message_body(spb::char_stream&, proto_messages&, proto_comment&&)’:
/home/tonda/tmp/simple-protobuf/src/spb-proto-compiler/parser/parser.cpp:756:10: note: ‘new_field’ declared here
  756 |     auto new_field = proto_field{
```
_Looks like a gcc 15.2.1 false positive, because only this version seems to report it..._