### PR TITLE
Fix: Add std::monostate to oneof std::variant (#67)

### DIFF
--- a/src/spb-proto-compiler/dumper/header.cpp
+++ b/src/spb-proto-compiler/dumper/header.cpp
@@ -368,16 +368,13 @@ void dump_message_oneof(std::ostream &stream, const proto_oneof &oneof, const pr
 {
     dump_comment(stream, oneof.comment);
 
-    auto put_comma = false;
-    stream << "std::variant< ";
+    
+    stream << "std::variant< std::monostate";
     for (const auto &field : oneof.fields)
     {
-        if (put_comma)
-            stream << ", ";
-
-        stream << convert_to_ctype(file, field);
-        put_comma = true;
+        stream << ", " << convert_to_ctype(file, field);
     }
+    
     stream << " > " << oneof.name.get_name() << ";\n";
 }
 

--- a/src/spb-proto-compiler/dumper/json/dumper.cpp
+++ b/src/spb-proto-compiler/dumper/json/dumper.cpp
@@ -211,9 +211,12 @@ void dump_cpp_serialize_field(std::ostream &stream, const proto_file &file, cons
 {
     stream << "\tconst auto index = value." << oneof.name.get_name() << ".index();\n";
     stream << "\tswitch(index)\n\t{\n";
+    // Add case 0 for monostate (empty state)
+    stream << "\t\tcase 0:\n\t\t\tbreak;  // monostate - empty oneof\n";
+    // All field indices shifted by 1
     for (size_t i = 0; i < oneof.fields.size(); ++i)
     {
-        stream << "\t\tcase " << i << ":\n\t\t\treturn serialize<";
+        stream << "\t\tcase " << (i + 1) << ":\n\t\t\treturn serialize<";
         dump_field_attributes(stream, file, message, oneof.fields[i]);
         stream << ">(stream, std::get<" << i << ">(value." << oneof.name.get_name() << "), \""
                << json_field_name(oneof.fields[i]) << "\"sv);\n";

--- a/src/spb-proto-compiler/dumper/pb/dumper.cpp
+++ b/src/spb-proto-compiler/dumper/pb/dumper.cpp
@@ -210,9 +210,12 @@ void dump_cpp_serialize_field(std::ostream &stream, const proto_file &file, cons
 {
     stream << "\t{\n\t\tconst auto index = value." << oneof.name.get_name() << ".index( );\n";
     stream << "\t\tswitch (index)\n\t\t{\n";
+    // Add case 0 for monostate (empty state)
+    stream << "\t\t\tcase 0:\n\t\t\t\tbreak;  // monostate - empty oneof\n";
+    // All field indices shifted by 1
     for (size_t i = 0; i < oneof.fields.size(); ++i)
     {
-        stream << "\t\t\tcase " << i << ":\n\t\t\t\treturn serialize<";
+        stream << "\t\t\tcase " << (i + 1) << ":\n\t\t\t\treturn serialize<";
         dump_serialize_mode(stream, file, message, oneof.fields[i]);
         stream << ">(stream, " << oneof.fields[i].number << ", std::get<" << i << ">(value."
                << oneof.name.get_name() << "));\n";


### PR DESCRIPTION
- Added std::monostate as first variant type for oneof fields
- Provides proper empty/unset state matching protobuf semantics
- Fixes #67
- 
## Description
Fixes #67 by adding std::monostate to std::variant for oneof fields.

## Changes
- Added std::monostate as first type in variant
- Provides empty state for oneof fields

## Testing
- CI will run tests
- Existing tests should pass